### PR TITLE
Sacrifice foresight for precision

### DIFF
--- a/src/Ephemeris/Transit.hs
+++ b/src/Ephemeris/Transit.hs
@@ -61,7 +61,11 @@ transit conn momentOfTransit a@(HoroscopeAspect _aspect' (transiting', transited
     -- only consider crossing candidates that are at most day before or after the reference date.
     let immediateCrossings = filter ((<= 1) . abs . (subtract momentOfTransit)) crossingCandidates
     -- this is the only moment where we actually touch swiss ephemeris:
-        exactImmediateCrossings =  [x | ExactAt x <- map (findExactTransitAround transitingPlanet transitAspectLongitude) immediateCrossings]
+        exactImmediateCrossings =  
+          if (not . null $ immediateCrossings) then
+            [x | ExactAt x <- map (findExactTransitAround transitingPlanet transitAspectLongitude) [momentOfTransit]]
+          else
+            []
     pure $
       Transit {
         transiting = transiting'

--- a/test/files/transitsText/golden
+++ b/test/files/transitsText/golden
@@ -163,7 +163,7 @@ Moon      |Square      |Chiron   |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 U
 Mercury   |BiQuintile  |Jupiter  |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 11:51:17 UTC 
 Mercury   |Conjunction |Uranus   |2020-12-21 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 06:24:23 UTC 
 Venus     |Sesquisquare|Mars     |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 00:34:10 UTC 
-Mars      |Conjunction |Mars     |2020-08-13 00:00:00 UTC |2020-12-25 00:00:00 UTC |2020-12-23 04:02:36 UTC 
+Mars      |Conjunction |Mars     |2020-08-13 00:00:00 UTC |2020-12-25 00:00:00 UTC |N/A                     
 Mars      |SemiSquare  |Mean Node|2020-08-14 00:00:00 UTC |2020-12-26 00:00:00 UTC |N/A                     
 Mars      |Quincunx    |Lilith   |2020-08-21 00:00:00 UTC |2020-12-31 00:00:00 UTC |N/A                     
 Uranus    |Square      |Mercury  |2020-05-26 00:00:00 UTC |2021-04-23 00:00:00 UTC |N/A                     


### PR DESCRIPTION
The immediate crossings notion was weird. We now simply
see if there's crossings in the bracket of 24 hours right
before or after the moment of query; vs. the latest of
the found crossing candidates -- this was proving to be
wildly inaccurate in the general case!

Still cool to see when crossings may happen though.