### PR TITLE
Fix exactitude angle

### DIFF
--- a/freenatalchart.cabal
+++ b/freenatalchart.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bc851fcc9d2a74cf790bb1011d8ab0296c33727270c2fc371b72c6e51715cf93
+-- hash: 33763d402ce634d8983f0ceb2dfb2aad31288926d8ccf3cf88921b304d0c8be5
 
 name:           freenatalchart
 version:        0.2.0.0
@@ -140,6 +140,7 @@ test-suite freenatalchart-test
   other-modules:
       Arbitrary
       Chart.PrerenderedSpec
+      Ephemeris.AspectSpec
       Ephemeris.HoroscopeSpec
       Ephemeris.TransitSpec
       Server.HandlersSpec

--- a/src/Chart/Graphics.hs
+++ b/src/Chart/Graphics.hs
@@ -20,7 +20,6 @@ import Ephemeris
       HoroscopeAspect(..),
       Longitude(Longitude),
       westernZodiacSigns,
-      angularDifference,
       isRetrograde,
       HoroscopeData(..),
       TransitData(..),
@@ -318,3 +317,13 @@ renderTransitChart attrs width' t@TransitData{..} =
         }
     transitChart' = transitChart cfg t # rotateBy ((ascendantOffset @@ deg) ^. turn)
     ascendantOffset = 180 - (ascendant natalAngles)
+
+-- | NOTE(luis) this only really works for spans
+-- between house cusps. See the much more precise functions
+-- Ephemeris.Aspect for calculating angles between longitudes,
+-- with apparent phase and orb.
+angularDifference :: Double -> Double -> Double
+angularDifference a b
+  | (b - a) & abs & (< 1) = abs $ b - a
+  | (b - a) & signum & (< 1) = (b + 360 - a)
+  | otherwise = b - a

--- a/src/Chart/Graphics.hs
+++ b/src/Chart/Graphics.hs
@@ -319,8 +319,8 @@ renderTransitChart attrs width' t@TransitData{..} =
     ascendantOffset = 180 - (ascendant natalAngles)
 
 -- | NOTE(luis) this only really works for spans
--- between house cusps. See the much more precise functions
--- Ephemeris.Aspect for calculating angles between longitudes,
+-- between house cusps. See the much more precise functions in
+-- `Ephemeris.Aspect` for calculating angles between longitudes,
 -- with apparent phase and orb.
 angularDifference :: Double -> Double -> Double
 angularDifference a b

--- a/src/Ephemeris/Aspect.hs
+++ b/src/Ephemeris/Aspect.hs
@@ -45,9 +45,7 @@ aspects' possibleAspects bodiesA bodiesB =
     pairs = [(x, y) | x <- bodiesA, y <- bodiesB]
     aspectsBetween bodyPair = map (haveAspect bodyPair) possibleAspects
     haveAspect (a, b) asp@Aspect {..} =
-      case (findAspectAngle asp a b) of
-        Nothing -> Nothing
-        Just angle' -> Just $ HoroscopeAspect {aspect=asp, bodies = (a,b), aspectAngle = angle'}
+      (findAspectAngle asp a b) <&> HoroscopeAspect asp (a,b)
 
 
 aspects :: (HasLongitude a, HasLongitude b) => [a] -> [b] -> [HoroscopeAspect a b]
@@ -112,26 +110,6 @@ findAspectsByName :: [HoroscopeAspect a b] -> AspectName -> [HoroscopeAspect a b
 findAspectsByName aspectList name =
   aspectList
     & filter (\HoroscopeAspect {..} -> (aspect & aspectName) == name)
-
-
-
-
--- TODO(luis): maybe we can use this in the aspect calculation, and anywhere
--- where we need to account for "0/360 jumps"?
--- still not sure on how sound the math is.
-eclipticDifference :: (HasLongitude a, HasLongitude b) => a -> b -> Double
-eclipticDifference a b =
-  if ((abs diff) >= biggerThanAnyAspect) then
-    lB - lA
-  else
-    diff
-  where
-    biggerThanAnyAspect = 200
-    diff = lA - lB
-    lA = getLongitudeRaw a
-    lB = getLongitudeRaw b
-
----
 
 findAspectAngle :: (HasLongitude a, HasLongitude b) => Aspect -> a -> b -> Maybe AspectAngle 
 findAspectAngle aspect aspecting aspected =

--- a/src/Ephemeris/Aspect.hs
+++ b/src/Ephemeris/Aspect.hs
@@ -6,6 +6,7 @@ import Import
 import Utils
 import Ephemeris.Types
 import RIO.List (headMaybe)
+import Ephemeris.Utils (isRetrograde)
 
 majorAspects :: [Aspect]
 majorAspects =
@@ -167,7 +168,7 @@ toLongitude (EclipticAngle e)
 
 exactAngle :: HoroscopeAspect a b -> Longitude
 exactAngle aspect' =
-  case (aspectAnglePhase angle') of
+  case (aspectAngleApparentPhase angle') of
     Applying   -> (EclipticAngle $ aspecting' + orb') & toLongitude
     Separating -> (EclipticAngle $ aspecting' - orb') & toLongitude
     Exact      -> a & toLongitude
@@ -184,5 +185,15 @@ currentAngle HoroscopeAspect{..} =
 orb :: HoroscopeAspect a b -> Double
 orb  = aspectAngleOrb . aspectAngle
 
-aspectPhase :: HoroscopeAspect a b -> AspectPhase
-aspectPhase = aspectAnglePhase . aspectAngle
+aspectPhase :: TransitAspect a -> AspectPhase
+aspectPhase asp = 
+  if aspectingIsRetrograde then
+    flipPhase $ aspectAngleApparentPhase angle'
+  else
+    aspectAngleApparentPhase angle'
+  where
+    flipPhase Applying = Separating
+    flipPhase Separating = Applying
+    flipPhase Exact = Exact
+    angle' = aspectAngle asp
+    aspectingIsRetrograde = asp & bodies & fst & isRetrograde

--- a/src/Ephemeris/Aspect.hs
+++ b/src/Ephemeris/Aspect.hs
@@ -5,7 +5,6 @@ module Ephemeris.Aspect where
 import Import
 import Utils
 import Ephemeris.Types
-import Ephemeris.Utils
 import RIO.List (headMaybe)
 
 majorAspects :: [Aspect]
@@ -38,19 +37,6 @@ defaultAspects = majorAspects <> minorAspects
 aspectsForTransits :: [Aspect]
 aspectsForTransits = defaultAspects-- map (\a -> a{maxOrb = 5.0}) majorAspects
 
--- TODO(luis) this may also suffer from the 0/360 false negative!
-exactAspectAngle ::  (HasLongitude a) => HoroscopeAspect a b -> Longitude
-exactAspectAngle (HoroscopeAspect aspect' (aspecting, _aspected) angle' orb') =
-  if angle' >= (angle aspect') then
-    Longitude $ aspectingLongitude - orb'
-  else
-    Longitude $ aspectingLongitude + orb'
-  where
-    aspectingLongitude = aspecting & getLongitudeRaw
-  
--- TODO: this is very wrong:
--- (note that the orb is considered to be the same as the angle??)
--- Sun      |Conjunction |Moon     |4.5267  |4.5267  |Applying
 aspects' :: (HasLongitude a, HasLongitude b) => [Aspect] -> [a] -> [b] -> [HoroscopeAspect a b]
 aspects' possibleAspects bodiesA bodiesB =
   (concatMap aspectsBetween pairs) & catMaybes
@@ -58,15 +44,10 @@ aspects' possibleAspects bodiesA bodiesB =
     pairs = [(x, y) | x <- bodiesA, y <- bodiesB]
     aspectsBetween bodyPair = map (haveAspect bodyPair) possibleAspects
     haveAspect (a, b) asp@Aspect {..} =
-      let angleBefore = angularDifference (getLongitudeRaw a) (getLongitudeRaw b)
-          orbBefore = (angle - (abs angleBefore)) & abs
-          angleAfter = angularDifference (getLongitudeRaw b) (getLongitudeRaw a)
-          orbAfter =  (angle - (abs angleAfter)) & abs
-        in if orbAfter <= maxOrb
-            then Just $ HoroscopeAspect {aspect = asp, bodies = (a, b), aspectAngle = angleAfter, orb = orbAfter}
-            else if orbBefore <= maxOrb then
-              Just $ HoroscopeAspect {aspect = asp, bodies = (a, b), aspectAngle = angleBefore, orb = orbBefore}
-              else Nothing
+      case (findAspectAngle asp a b) of
+        Nothing -> Nothing
+        Just angle' -> Just $ HoroscopeAspect {aspect=asp, bodies = (a,b), aspectAngle = angle'}
+
 
 aspects :: (HasLongitude a, HasLongitude b) => [a] -> [b] -> [HoroscopeAspect a b]
 aspects = aspects' defaultAspects
@@ -131,26 +112,8 @@ findAspectsByName aspectList name =
   aspectList
     & filter (\HoroscopeAspect {..} -> (aspect & aspectName) == name)
 
--- | Is the aspecting body approaching, or leaving, exactitude?
--- NOTE: we assume that the aspected body is static, which is a correct
--- assumption for transits, in which the aspected natal bodies are fixed,
--- but it's not necessarily correct for natal charts, in which both
--- bodies were in motion.
--- More on these:
--- https://www.astro.com/astrowiki/en/Applying_Aspect
--- https://www.astro.com/astrowiki/en/Separating_Aspect
-aspectPhase :: HoroscopeAspect PlanetPosition a -> AspectPhase
-aspectPhase asp@HoroscopeAspect {..} =
-  if isMovingTowards then
-    Applying 
-  else
-    Separating
-  where
-    isMovingTowards = isDirect && isApproaching
-    isDirect = (== 1) . signum . planetLngSpeed $ aspectingPlanet
-    isApproaching = (< 1) . signum $ eclipticDifference aspectingPlanet aspectedPoint
-    aspectingPlanet = bodies & fst
-    aspectedPoint   = exactAspectAngle asp
+
+
 
 -- TODO(luis): maybe we can use this in the aspect calculation, and anywhere
 -- where we need to account for "0/360 jumps"?
@@ -169,29 +132,29 @@ eclipticDifference a b =
 
 ---
 
-findAspectAngle :: (Num a, Num b, HasLongitude a, HasLongitude b) => Aspect -> a -> b -> Maybe AspectAngle 
+findAspectAngle :: (HasLongitude a, HasLongitude b) => Aspect -> a -> b -> Maybe AspectAngle 
 findAspectAngle aspect aspecting aspected =
-  (aspectAngle' aspect aspecting           aspected )<|> 
-  (aspectAngle' aspect (aspecting + 360)   aspected) <|>
-  (aspectAngle' aspect aspecting           (aspected + 360))
+  (aspectAngle' aspect aspecting                        aspected) <|> 
+  (aspectAngle' aspect (aspecting `addLongitude` 360)   aspected) <|>
+  (aspectAngle' aspect aspecting                        (aspected `addLongitude` 360))
 
 aspectAngle' :: (HasLongitude a, HasLongitude b) => Aspect -> a -> b -> Maybe AspectAngle 
 aspectAngle' Aspect{..} aspecting aspected =
   if inOrb then
     case ((compare (getLongitude aspecting) (getLongitude aspected)), (compare angleDiff angle)) of
-      (LT, GT) -> Just $ InOrb aspecting' Applying orb  
-      (LT, LT) -> Just $ InOrb aspecting' Separating orb
+      (LT, GT) -> Just $ InOrb aspecting' Applying orb'  
+      (LT, LT) -> Just $ InOrb aspecting' Separating orb'
       (_, EQ)  -> Just $ Exact aspecting'
       (EQ, _)  -> Just $ Exact aspecting'
-      (GT, GT) -> Just $ InOrb aspecting' Separating orb
-      (GT, LT) -> Just $ InOrb aspecting' Applying orb
+      (GT, GT) -> Just $ InOrb aspecting' Separating orb'
+      (GT, LT) -> Just $ InOrb aspecting' Applying orb'
   else
     Nothing
   where
     aspecting' = EclipticAngle $ getLongitudeRaw aspecting
     angleDiff = abs $ (getLongitudeRaw aspecting) - (getLongitudeRaw aspected)
-    orb = abs $ angle - angleDiff
-    inOrb = orb <= maxOrb
+    orb' = abs $ angle - angleDiff
+    inOrb = orb' <= maxOrb
 
 toLongitude :: EclipticAngle -> Longitude
 toLongitude (EclipticAngle e)
@@ -200,7 +163,27 @@ toLongitude (EclipticAngle e)
   | e < 0     = Longitude . abs $ 360 + e
   | otherwise = Longitude e
 
-exactAngle :: AspectAngle -> Longitude
-exactAngle (InOrb (EclipticAngle a) Applying orb) = (EclipticAngle $ a + orb ) & toLongitude
-exactAngle (InOrb (EclipticAngle a) Separating orb) = (EclipticAngle $ a - orb ) & toLongitude
-exactAngle (Exact a) = toLongitude a
+exactAngle :: HoroscopeAspect a b -> Longitude
+exactAngle aspect' =
+  case (aspectAngle aspect') of
+    (InOrb (EclipticAngle a) Applying orb')   -> (EclipticAngle $ a + orb') & toLongitude
+    (InOrb (EclipticAngle a) Separating orb') -> (EclipticAngle $ a - orb') & toLongitude
+    (InOrb ea                Active _orb')     -> ea                         & toLongitude
+    (Exact a) -> toLongitude a
+
+currentAngle :: (HasLongitude a, HasLongitude b) => HoroscopeAspect a b -> Longitude
+currentAngle HoroscopeAspect{..} =
+  abs $ (bodies & fst & getLongitude) - (bodies & snd & getLongitude)
+
+
+orb :: HoroscopeAspect a b -> Double
+orb a =
+  case (aspectAngle a) of
+    InOrb _ _ o -> o
+    Exact _ -> 0
+
+aspectPhase :: HoroscopeAspect a b -> AspectPhase
+aspectPhase aspect' =
+  case (aspectAngle aspect') of
+    (InOrb _ p _) -> p
+    Exact _ -> Active

--- a/src/Ephemeris/Internal/Database.hs
+++ b/src/Ephemeris/Internal/Database.hs
@@ -174,6 +174,11 @@ orbAfter planet (Longitude lng) orb =
   where
     preferredOrb = max (maxSpeed planet) orb
 
+-- | TODO(luis) this is a stopgap for incomplete queries,
+-- see `toLongitude` in `Ephemeris.Aspect` for a better
+-- "keep in ecliptic" function, which can yield nonsensical
+-- ranges as far as query is concerned -- hence the necessity
+-- to also fix the queries.
 eclipticVal :: Double -> Longitude
 eclipticVal v | v >= 360 = Longitude 360
               | v < 0    = Longitude 0

--- a/src/Ephemeris/Transit.hs
+++ b/src/Ephemeris/Transit.hs
@@ -18,7 +18,7 @@ import Control.Monad (ap)
 import Ephemeris.Internal.Approximations (maxSpeed)
 import Database.SQLite.Simple (withConnection)
 import Database.SQLite.Simple.Internal (Connection)
-import Ephemeris.Aspect (exactAspectAngle)
+import Ephemeris.Aspect (exactAngle)
 import Ephemeris.Internal.Database (crossingCandidatesQuery, activityPeriodQuery)
 import Ephemeris.Utils (julianToUTC)
 import RIO.List (sortBy)
@@ -51,9 +51,9 @@ isActiveTransit moment Transit {..} =
   (maybe True (>= moment) transitEnds)
 
 transit :: Connection -> JulianTime -> TransitAspect a -> IO (Transit a)
-transit conn momentOfTransit a@(HoroscopeAspect _aspect' (transiting', transited') _angle' _orb') = 
+transit conn momentOfTransit a@(HoroscopeAspect _aspect' (transiting', transited') _angle') = 
   do
-    let transitAspectLongitude = exactAspectAngle a
+    let transitAspectLongitude = a & exactAngle
         transitingPlanet = transiting' & planetName
     (activityStarts, activityEnds) <- activityPeriodQuery conn transitingPlanet transitAspectLongitude momentOfTransit
     crossingCandidates <- crossingCandidatesQuery conn transitingPlanet transitAspectLongitude momentOfTransit

--- a/src/Ephemeris/Types.hs
+++ b/src/Ephemeris/Types.hs
@@ -195,10 +195,10 @@ newtype EclipticAngle
 
 data AspectAngle
   = AspectAngle {
-    aspectingPosition :: EclipticAngle
-  , aspectedPosition  :: EclipticAngle
-  , aspectAnglePhase  :: AspectPhase
-  , aspectAngleOrb    :: Double
+    aspectingPosition         :: EclipticAngle
+  , aspectedPosition          :: EclipticAngle
+  , aspectAngleApparentPhase  :: AspectPhase
+  , aspectAngleOrb            :: Double
   }
   deriving stock (Eq, Show)
 

--- a/src/Ephemeris/Types.hs
+++ b/src/Ephemeris/Types.hs
@@ -181,21 +181,25 @@ data AspectType
 data AspectPhase
   = Applying
   | Separating
-  | Active
+  | Exact
   deriving stock (Eq, Show, Ord, Enum)
 
 instance HasLabel AspectPhase where
   label Applying = "a"
   label Separating  = "s"
-  label Active = ""
+  label Exact = ""
 
 newtype EclipticAngle 
-  = EclipticAngle Double
+  = EclipticAngle {unEclipticAngle :: Double}
   deriving newtype (Eq, Show, Num)
 
 data AspectAngle
-  = Exact EclipticAngle
-  | InOrb EclipticAngle AspectPhase Double
+  = AspectAngle {
+    aspectingPosition :: EclipticAngle
+  , aspectedPosition  :: EclipticAngle
+  , aspectAnglePhase  :: AspectPhase
+  , aspectAngleOrb    :: Double
+  }
   deriving stock (Eq, Show)
 
 data Aspect = Aspect 

--- a/src/Ephemeris/Types.hs
+++ b/src/Ephemeris/Types.hs
@@ -41,6 +41,8 @@ module Ephemeris.Types
   , HoroscopeData(..)
   , Transit(..)
   , TransitData(..)
+  , EclipticAngle(..)
+  , AspectAngle(..)
   -- smart constructors
   , mkLatitude
   , mkLongitude
@@ -173,6 +175,15 @@ data AspectPhase
 instance HasLabel AspectPhase where
   label Applying = "a"
   label Separating  = "s"
+
+newtype EclipticAngle 
+  = EclipticAngle Double
+  deriving newtype (Eq, Show, Num)
+
+data AspectAngle
+  = Exact EclipticAngle
+  | InOrb EclipticAngle AspectPhase Double
+  deriving stock (Eq, Show)
 
 data Aspect = Aspect 
   { aspectName :: AspectName

--- a/src/Ephemeris/Utils.hs
+++ b/src/Ephemeris/Utils.hs
@@ -5,16 +5,9 @@ import Ephemeris.Types
 import RIO.Time (fromGregorian, picosecondsToDiffTime, diffTimeToPicoseconds, toGregorian, UTCTime(..))
 import SwissEphemeris(julianDay, defaultSplitDegreesOptions, gregorianDateTime)
 import qualified SwissEphemeris as SWE
-import Import
 
 mkEcliptic :: EclipticPosition
 mkEcliptic = EclipticPosition 0 0 0 0 0 0
-
-angularDifference :: Double -> Double -> Double
-angularDifference a b
-  | (b - a) & abs & (< 1) = abs $ b - a
-  | (b - a) & signum & (< 1) = (b + 360 - a)
-  | otherwise = b - a
 
 isRetrograde :: PlanetPosition -> Bool
 isRetrograde PlanetPosition {..} =

--- a/src/Views/Chart.hs
+++ b/src/Views/Chart.hs
@@ -114,7 +114,7 @@ renderText _ BirthData {..} HoroscopeData{..}=
       tell "|"
       tell . justifyAspected . labelText . planetName $ aspected
       tell "|"
-      tell . justifyDouble . pack . formatLongitude . currentAngle $ a'
+      tell . justifyDouble . pack . formatDouble . unEclipticAngle . currentAngle $ a'
       tell "|"
       tell . justifyDouble . pack . formatDouble . orb $ a'
       ln_ ""
@@ -129,7 +129,7 @@ renderText _ BirthData {..} HoroscopeData{..}=
       tell "|"
       tell . justifyAspected . houseAspectLabel . houseNumber $ aspected
       tell "|"
-      tell . justifyDouble . pack . formatLongitude . currentAngle $ a'
+      tell . justifyDouble . pack . formatDouble . unEclipticAngle . currentAngle $ a'
       tell "|"
       tell . justifyDouble . pack . formatDouble . orb $ a'
       ln_ ""

--- a/src/Views/Chart/Common.hs
+++ b/src/Views/Chart/Common.hs
@@ -64,6 +64,9 @@ asIcon z =
 formatDouble :: Double -> String
 formatDouble = printf "%.4f"
 
+formatLongitude :: HasLongitude a => a -> String
+formatLongitude = formatDouble . getLongitudeRaw
+
 htmlDegreesZodiac :: HasLongitude a => a -> Html ()
 htmlDegreesZodiac p =
   span_ [title_ . pack . formatDouble $ pl] $ do
@@ -235,11 +238,11 @@ houseLabel _ = mempty
 
 aspectCell :: Maybe (HoroscopeAspect a b) -> Html ()
 aspectCell Nothing = mempty
-aspectCell (Just HoroscopeAspect {..}) =
+aspectCell (Just a@HoroscopeAspect {..}) =
   span_ [aspectColorStyle aspect] $ do
     asIcon . aspectName $ aspect
     " "
-    htmlDegrees' (True, False) orb
+    htmlDegrees' (True, False) (orb a)
 
 -- | aspect cell, but specialized to the aspecting body being a planet.
 planetaryAspectCell :: Maybe (HoroscopeAspect PlanetPosition a) -> Html ()
@@ -248,7 +251,7 @@ planetaryAspectCell (Just (a@HoroscopeAspect {..})) =
   span_ [aspectColorStyle aspect] $ do
     asIcon . aspectName $ aspect
     " "
-    htmlDegrees' (True, False) orb
+    htmlDegrees' (True, False) (orb a)
     span_ [class_ "text-tiny tooltip", data_ "tooltip" (pack . show $ phase)] $ do
       toHtml . pack . label $ phase
   where

--- a/src/Views/Chart/Common.hs
+++ b/src/Views/Chart/Common.hs
@@ -245,7 +245,7 @@ aspectCell (Just a@HoroscopeAspect {..}) =
     htmlDegrees' (True, False) (orb a)
 
 -- | aspect cell, but specialized to the aspecting body being a planet.
-planetaryAspectCell :: Maybe (HoroscopeAspect PlanetPosition a) -> Html ()
+planetaryAspectCell :: Maybe (TransitAspect a) -> Html ()
 planetaryAspectCell Nothing = mempty
 planetaryAspectCell (Just (a@HoroscopeAspect {..})) =
   span_ [aspectColorStyle aspect] $ do

--- a/src/Views/Chart/Common.hs
+++ b/src/Views/Chart/Common.hs
@@ -64,9 +64,6 @@ asIcon z =
 formatDouble :: Double -> String
 formatDouble = printf "%.4f"
 
-formatLongitude :: HasLongitude a => a -> String
-formatLongitude = formatDouble . getLongitudeRaw
-
 htmlDegreesZodiac :: HasLongitude a => a -> Html ()
 htmlDegreesZodiac p =
   span_ [title_ . pack . formatDouble $ pl] $ do

--- a/src/Views/Transits.hs
+++ b/src/Views/Transits.hs
@@ -103,22 +103,22 @@ aspectsHeading =
     , justifyDouble "Orb", "Phase"
     ]
 
-transitActivity :: HasLabel a => Text -> UTCTime -> [(TransitAspect a, Transit a)] -> (Writer Text ())
+transitActivity :: (HasLabel a, HasLongitude a) => Text -> UTCTime -> [(TransitAspect a, Transit a)] -> (Writer Text ())
 transitActivity extraHeading moment transits' = do
   ln_ ""
   ln_ $ "All Aspects " <> extraHeading
   ln_ $ "~~~~~~~~~~~~" <> pack (repeat '~' & take (T.length extraHeading))
   ln_ aspectsHeading
-  forM_  (transitAspects transits') $ \a@(HoroscopeAspect aspect (aspecting, aspected) angle orb) -> do
+  forM_  (transitAspects transits') $ \a@(HoroscopeAspect aspect (aspecting, aspected) _angle) -> do
     tell . justifyAspecting . labelText . planetName $ aspecting
     tell "|"
     tell . justifyAspect . labelText . aspectName $ aspect
     tell "|"
     tell . justifyAspected . labelText  $ aspected
     tell "|"
-    tell . justifyDouble . pack $ formatDouble angle
+    tell . justifyDouble . pack . formatDouble . getLongitudeRaw . currentAngle $ a
     tell "|"
-    tell . justifyDouble . pack $ formatDouble orb
+    tell . justifyDouble . pack . formatDouble . orb $ a
     tell "|"
     tell . pack . show $ aspectPhase a
     ln_ ""

--- a/src/Views/Transits.hs
+++ b/src/Views/Transits.hs
@@ -103,7 +103,7 @@ aspectsHeading =
     , justifyDouble "Orb", "Phase"
     ]
 
-transitActivity :: (HasLabel a, HasLongitude a) => Text -> UTCTime -> [(TransitAspect a, Transit a)] -> (Writer Text ())
+transitActivity :: HasLabel a => Text -> UTCTime -> [(TransitAspect a, Transit a)] -> (Writer Text ())
 transitActivity extraHeading moment transits' = do
   ln_ ""
   ln_ $ "All Aspects " <> extraHeading
@@ -116,7 +116,7 @@ transitActivity extraHeading moment transits' = do
     tell "|"
     tell . justifyAspected . labelText  $ aspected
     tell "|"
-    tell . justifyDouble . pack . formatDouble . getLongitudeRaw . currentAngle $ a
+    tell . justifyDouble . pack . formatDouble . unEclipticAngle . currentAngle $ a
     tell "|"
     tell . justifyDouble . pack . formatDouble . orb $ a
     tell "|"

--- a/test/Ephemeris/AspectSpec.hs
+++ b/test/Ephemeris/AspectSpec.hs
@@ -14,18 +14,20 @@ spec = do
   describe "findAspectAngle" $ do
     let assertions = 
           [
-            ((Longitude 175, Longitude 270), Just (Applying, 5))
-          , ((Longitude 185, Longitude 270), Just (Separating, 5))
-          , ((Longitude 270, Longitude 270), Nothing)
-          , ((Longitude 355, Longitude 270), Just (Applying, 5))
-          , ((Longitude 5,   Longitude 270), Just (Separating, 5))
-          , ((Longitude 270, Longitude 10),  Just (Applying, 10))
-          , ((Longitude 290, Longitude 10),  Just (Separating, 10))
-          , ((Longitude 95,  Longitude 10),  Just (Applying, 5))
-          , ((Longitude 100, Longitude 10),  Just (Exact, 0))
-          , ((Longitude 130, Longitude 10),  Nothing)
+            (sq, (Longitude 175, Longitude 270), Just (Applying, 5))
+          , (sq, (Longitude 185, Longitude 270), Just (Separating, 5))
+          , (sq, (Longitude 270, Longitude 270), Nothing)
+          , (sq, (Longitude 355, Longitude 270), Just (Applying, 5))
+          , (sq, (Longitude 5,   Longitude 270), Just (Separating, 5))
+          , (sq, (Longitude 270, Longitude 10),  Just (Applying, 10))
+          , (sq, (Longitude 290, Longitude 10),  Just (Separating, 10))
+          , (sq, (Longitude 95,  Longitude 10),  Just (Applying, 5))
+          , (sq, (Longitude 100, Longitude 10),  Just (Exact, 0))
+          , (sq, (Longitude 130, Longitude 10),  Nothing)
+          , (cnj, (Longitude 270, Longitude 270), Just (Exact, 0) )
           ]
         sq = Aspect{ aspectType = Major, aspectName = Square, angle = 90.0, maxOrb = 10.0, temperament = Analytical }
-    forM_ assertions $ \((aspecting', aspected'), expected) ->
-      it (printf "Determines square aspect angle and apparent phase between %.2f and %.2f" (aspecting' & getLongitudeRaw) (aspected' & getLongitudeRaw)) $
-        (findAspectAngle sq aspecting' aspected' <&> phaseAndOrb) `shouldBe` expected
+        cnj = Aspect{ aspectType = Major, aspectName = Conjunction, angle = 0.0, maxOrb = 10.0, temperament = Analytical }
+    forM_ assertions $ \(aspect', (aspecting', aspected'), expected) ->
+      it (printf "Determines aspect angle and apparent phase between %.2f and %.2f" (aspecting' & getLongitudeRaw) (aspected' & getLongitudeRaw)) $
+        (findAspectAngle aspect' aspecting' aspected' <&> phaseAndOrb) `shouldBe` expected

--- a/test/Ephemeris/AspectSpec.hs
+++ b/test/Ephemeris/AspectSpec.hs
@@ -12,11 +12,20 @@ phaseAndOrb (AspectAngle _aspecting _aspected phase orb') = (phase, orb')
 spec :: Spec
 spec = do
   describe "findAspectAngle" $ do
-      let assertions = 
-            [
-              ((Longitude 175, Longitude 270), Just (Applying, 5))
-            ]
-          sq = Aspect{ aspectType = Major, aspectName = Square, angle = 90.0, maxOrb = 10.0, temperament = Analytical }
-      forM_ assertions $ \((aspecting', aspected'), expected) ->
-        it "Finds aspect angles" $
-          (findAspectAngle sq aspecting' aspected' <&> phaseAndOrb) `shouldBe` expected
+    let assertions = 
+          [
+            ((Longitude 175, Longitude 270), Just (Applying, 5))
+          , ((Longitude 185, Longitude 270), Just (Separating, 5))
+          , ((Longitude 270, Longitude 270), Nothing)
+          , ((Longitude 355, Longitude 270), Just (Applying, 5))
+          , ((Longitude 5,   Longitude 270), Just (Separating, 5))
+          , ((Longitude 270, Longitude 10),  Just (Applying, 10))
+          , ((Longitude 290, Longitude 10),  Just (Separating, 10))
+          , ((Longitude 95,  Longitude 10),  Just (Applying, 5))
+          , ((Longitude 100, Longitude 10),  Just (Exact, 0))
+          , ((Longitude 130, Longitude 10),  Nothing)
+          ]
+        sq = Aspect{ aspectType = Major, aspectName = Square, angle = 90.0, maxOrb = 10.0, temperament = Analytical }
+    forM_ assertions $ \((aspecting', aspected'), expected) ->
+      it (printf "Determines square aspect angle and apparent phase between %.2f and %.2f" (aspecting' & getLongitudeRaw) (aspected' & getLongitudeRaw)) $
+        (findAspectAngle sq aspecting' aspected' <&> phaseAndOrb) `shouldBe` expected

--- a/test/Ephemeris/AspectSpec.hs
+++ b/test/Ephemeris/AspectSpec.hs
@@ -1,0 +1,22 @@
+module Ephemeris.AspectSpec (spec) where
+
+import Ephemeris.Aspect
+import Ephemeris.Types
+import Test.Hspec (shouldBe, it, describe, Spec)
+import RIO ((&), (<&>), forM_)
+import Text.Printf (printf)
+
+phaseAndOrb :: AspectAngle -> (AspectPhase, Double)
+phaseAndOrb (AspectAngle _aspecting _aspected phase orb') = (phase, orb')
+
+spec :: Spec
+spec = do
+  describe "findAspectAngle" $ do
+      let assertions = 
+            [
+              ((Longitude 175, Longitude 270), Just (Applying, 5))
+            ]
+          sq = Aspect{ aspectType = Major, aspectName = Square, angle = 90.0, maxOrb = 10.0, temperament = Analytical }
+      forM_ assertions $ \((aspecting', aspected'), expected) ->
+        it "Finds aspect angles" $
+          (findAspectAngle sq aspecting' aspected' <&> phaseAndOrb) `shouldBe` expected

--- a/test/TestUtil.hs
+++ b/test/TestUtil.hs
@@ -12,13 +12,16 @@ goldenFixture :: String -> String -> Golden String
 goldenFixture name output_ =
   Golden {
     output = output_
-  , encodePretty = show
+  , encodePretty = const $ "HMTL diffs not supported. Please compare updated test/files" <> name <> "/actual in a browser, or format + diff manually."
   , testName = name
   , writeToFile = writeFile
   , readFromFile = readFile
   , directory = "test/files"
   , failFirstTime = False
   }
+
+goldenFixtureHTML :: String -> String -> Golden String
+goldenFixtureHTML = goldenFixture
 
 goldenFixtureText :: String -> T.Text -> Golden T.Text
 goldenFixtureText name output_ =

--- a/test/Views/ChartSpec.hs
+++ b/test/Views/ChartSpec.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Views.ChartSpec (spec) where
 
-import TestUtil (testTzDB, goldenFixture, renderHtmlToString, testEphe)
+import TestUtil (goldenFixtureText, testTzDB, goldenFixture, renderHtmlToString, testEphe)
 import Views.Common (fixtureRenderContext)
-import Views.Chart (render)
+import Views.Chart (render, renderText)
 import Test.Hspec ( context, describe, it, Spec )
 import Import
 import RIO.Time ( defaultTimeLocale, parseTimeM )
@@ -26,9 +26,25 @@ renderHoroscope = unsafePerformIO $ do
   horoscope' <- horoscope tzDB testEphe birthData
   return $ renderHtmlToString $ render fixtureRenderContext birthData horoscope'
 
+renderHoroscopeText :: Text
+renderHoroscopeText = unsafePerformIO $ do
+  birthTime <- parseTimeM True defaultTimeLocale "%Y-%-m-%-d %T" "1989-01-06 00:30:00" 
+  tzDB <- testTZDB
+  let birthData = 
+        BirthData
+        (Location "Teguz" (Latitude 14.0839053) (Longitude $ -87.2750137))
+        birthTime
+  horoscope' <- horoscope tzDB testEphe birthData
+  return $ renderText fixtureRenderContext birthData horoscope'
+
 spec :: Spec
-spec =
+spec = do
   describe "Chart page" $ do
     context "when given valid birth data" $ do
       it "renders a full chart page" $ do
         goldenFixture "natalChart" renderHoroscope
+
+  describe "Chart page, text version" $ do
+    context "when given valid birth data" $ do
+      it "renders a full chart page, in text" $ do
+        goldenFixtureText "natalChartText" renderHoroscopeText

--- a/test/files/natalChartText/golden
+++ b/test/files/natalChartText/golden
@@ -126,13 +126,13 @@ Lilith   |Trine       |Jupiter  |119.8796|0.1204
 Lilith   |Square      |Saturn   |99.9058 |9.9058  
 Lilith   |Square      |Uranus   |95.7597 |5.7597  
 Lilith   |Square      |Chiron   |82.7880 |7.2120  
-Chiron   |Opposition  |Moon     |187.3588|7.3588  
+Chiron   |Opposition  |Moon     |172.6412|7.3588  
 Chiron   |Quincunx    |Mercury  |148.8628|1.1372  
-Chiron   |Opposition  |Venus    |189.1324|9.1324  
+Chiron   |Opposition  |Venus    |170.8676|9.1324  
 Chiron   |Quintile    |Mars     |70.5932 |1.4068  
-Chiron   |Opposition  |Saturn   |177.3062|2.6938  
-Chiron   |Opposition  |Uranus   |181.4522|1.4522  
-Chiron   |Opposition  |Neptune  |173.3987|6.6013  
+Chiron   |Opposition  |Saturn   |182.6938|2.6938  
+Chiron   |Opposition  |Uranus   |178.5478|1.4522  
+Chiron   |Opposition  |Neptune  |186.6013|6.6013  
 Chiron   |Trine       |Mean Node|116.0108|3.9892  
 Chiron   |Square      |Lilith   |82.7880 |7.2120  
 
@@ -146,7 +146,7 @@ Moon     |Quincunx    |MC       |152.0120|2.0120
 Mercury  |Square      |Asc      |99.2435 |9.2435  
 Venus    |Sextile     |Asc      |58.9740 |1.0260  
 Venus    |Quincunx    |MC       |150.2384|0.2384  
-Mars     |Opposition  |Asc      |177.5132|2.4868  
+Mars     |Opposition  |Asc      |182.4868|2.4868  
 Mars     |Square      |MC       |91.2224 |1.2224  
 Jupiter  |Quincunx    |Asc      |148.9852|1.0148  
 Jupiter  |Sextile     |MC       |57.7208 |2.2792  

--- a/test/files/natalChartText/golden
+++ b/test/files/natalChartText/golden
@@ -1,0 +1,159 @@
+Freenatalchart.xyz
+==================
+
+Horoscope for:
+1989-01-06 06:30:00 UTC
+Teguz  (87w16, 14n5)
+
+Sun sign: Capricorn
+Moon: Sagittarius
+Ascendant: Libra
+
+Planet Positions
+----------------
+Planet       |House|Longitude|Speed   |Latitude|Declination|Zodiac Longitude
+Sun          |3    |285.9234 |1.0197  |-0.0001 |-22.4930   |♑️ 15° 55' 24"
+Moon         |3    |266.1612 |13.6359 |-4.8030 |-28.1881   |♐️ 26° 9' 40"
+Mercury      |4    |304.6572 |1.2569  |-1.3025 |-20.3661   |♒️ 4° 39' 26"
+Venus        |2    |264.3876 |1.2513  |0.5999  |-22.7245   |♐️ 24° 23' 15"
+Mars         |6    |22.9268  |0.5246  |0.6525  |9.5214     |♈️ 22° 55' 37"
+Jupiter (r)  |8    |56.4284  |-0.0480 |-0.8774 |18.5050    |♉️ 26° 25' 42"
+Saturn       |3    |276.2138 |0.1173  |0.7122  |-22.5856   |♑️ 6° 12' 50"
+Uranus       |3    |272.0677 |0.0592  |-0.2201 |-23.6468   |♑️ 2° 4' 4"
+Neptune      |3    |280.1213 |0.0378  |0.9024  |-22.1570   |♑️ 10° 7' 17"
+Pluto        |1    |224.6882 |0.0238  |15.6315 |-1.2732    |♏️ 14° 41' 17"
+Mean Node    |5    |337.5092 |-0.0529 |0.0000  |-8.7536    |♓️ 7° 30' 33"
+Lilith       |12   |176.3080 |0.1109  |-1.6621 |-0.0575    |♍️ 26° 18' 29"
+Chiron (r)   |9    |93.5200  |-0.0638 |-6.8491 |16.5492    |♋️ 3° 31' 12"
+
+House Cusps( Placidus )
+-----------
+House|Cusp    |Declination|Zodiac Longitude
+1    |205.4136|-9.8303    |♎️ 25° 24' 49"
+2    |235.0820|-19.0391   |♏️ 25° 4' 55"
+3    |264.4682|-23.3272   |♐️ 24° 28' 5"
+4    |294.1492|-21.2856   |♑️ 24° 8' 57"
+5    |324.8848|-13.2290   |♒️ 24° 53' 5"
+6    |355.9808|-1.5979    |♓️ 25° 58' 51"
+7    |25.4136 |9.8303     |♈️ 25° 24' 49"
+8    |55.0820 |19.0391    |♉️ 25° 4' 55"
+9    |84.4682 |23.3272    |♊️ 24° 28' 5"
+10   |114.1492|21.2856    |♋️ 24° 8' 57"
+11   |144.8848|13.2290    |♌️ 24° 53' 5"
+12   |175.9808|1.5979     |♍️ 25° 58' 51"
+
+Planetary Aspects
+-----------------
+Aspecting|Aspect      |Aspected |Angle   |Orb     
+Sun      |Square      |Mars     |97.0034 |7.0034  
+Sun      |Conjunction |Saturn   |9.7096  |9.7096  
+Sun      |Conjunction |Neptune  |5.8021  |5.8021  
+Sun      |Sextile     |Pluto    |61.2352 |1.2352  
+Moon     |Conjunction |Venus    |1.7736  |1.7736  
+Moon     |Trine       |Mars     |116.7656|3.2344  
+Moon     |Quincunx    |Jupiter  |150.2673|0.2673  
+Moon     |Conjunction |Uranus   |5.9066  |5.9066  
+Moon     |Quintile    |Mean Node|71.3480 |0.6520  
+Moon     |Square      |Lilith   |89.8532 |0.1468  
+Moon     |Opposition  |Chiron   |172.6412|7.3588  
+Mercury  |Trine       |Jupiter  |111.7713|8.2287  
+Mercury  |SemiSextile |Saturn   |28.4434 |1.5566  
+Mercury  |SemiSextile |Uranus   |32.5894 |2.5894  
+Mercury  |SemiSextile |Mean Node|32.8520 |2.8520  
+Mercury  |Trine       |Lilith   |128.3491|8.3491  
+Mercury  |Quincunx    |Chiron   |148.8628|1.1372  
+Venus    |Conjunction |Moon     |1.7736  |1.7736  
+Venus    |Trine       |Mars     |118.5392|1.4608  
+Venus    |Quincunx    |Jupiter  |152.0408|2.0408  
+Venus    |Conjunction |Uranus   |7.6802  |7.6802  
+Venus    |Quintile    |Mean Node|73.1216 |1.1216  
+Venus    |Square      |Lilith   |88.0796 |1.9204  
+Venus    |Opposition  |Chiron   |170.8676|9.1324  
+Mars     |Trine       |Moon     |116.7656|3.2344  
+Mars     |Trine       |Venus    |118.5392|1.4608  
+Mars     |Trine       |Uranus   |110.8591|9.1409  
+Mars     |SemiSquare  |Mean Node|45.4177 |0.4177  
+Mars     |Quintile    |Chiron   |70.5932 |1.4068  
+Mars     |Square      |Sun      |97.0034 |7.0034  
+Jupiter  |Quincunx    |Moon     |150.2673|0.2673  
+Jupiter  |Trine       |Mercury  |111.7713|8.2287  
+Jupiter  |Quincunx    |Venus    |152.0408|2.0408  
+Jupiter  |BiQuintile  |Uranus   |144.3607|0.3607  
+Jupiter  |Sesquisquare|Neptune  |136.3072|1.3072  
+Jupiter  |Trine       |Lilith   |119.8796|0.1204  
+Saturn   |SemiSextile |Mercury  |28.4434 |1.5566  
+Saturn   |Conjunction |Uranus   |4.1460  |4.1460  
+Saturn   |Conjunction |Neptune  |3.9075  |3.9075  
+Saturn   |Sextile     |Mean Node|61.2954 |1.2954  
+Saturn   |Square      |Lilith   |99.9058 |9.9058  
+Saturn   |Opposition  |Chiron   |182.6938|2.6938  
+Saturn   |Conjunction |Sun      |9.7096  |9.7096  
+Uranus   |Conjunction |Moon     |5.9066  |5.9066  
+Uranus   |SemiSextile |Mercury  |32.5894 |2.5894  
+Uranus   |Conjunction |Venus    |7.6802  |7.6802  
+Uranus   |Trine       |Mars     |110.8591|9.1409  
+Uranus   |BiQuintile  |Jupiter  |144.3607|0.3607  
+Uranus   |Conjunction |Saturn   |4.1460  |4.1460  
+Uranus   |Conjunction |Neptune  |8.0535  |8.0535  
+Uranus   |SemiSquare  |Pluto    |47.3796 |2.3796  
+Uranus   |Sextile     |Mean Node|65.4414 |5.4414  
+Uranus   |Square      |Lilith   |95.7597 |5.7597  
+Uranus   |Opposition  |Chiron   |178.5478|1.4522  
+Neptune  |Sesquisquare|Jupiter  |136.3072|1.3072  
+Neptune  |Conjunction |Saturn   |3.9075  |3.9075  
+Neptune  |Conjunction |Uranus   |8.0535  |8.0535  
+Neptune  |Sextile     |Pluto    |55.4331 |4.5669  
+Neptune  |Sextile     |Mean Node|57.3879 |2.6121  
+Neptune  |Opposition  |Chiron   |186.6013|6.6013  
+Neptune  |Conjunction |Sun      |5.8021  |5.8021  
+Pluto    |SemiSquare  |Uranus   |47.3796 |2.3796  
+Pluto    |Sextile     |Neptune  |55.4331 |4.5669  
+Pluto    |Trine       |Mean Node|112.8210|7.1790  
+Pluto    |Sextile     |Sun      |61.2352 |1.2352  
+Mean Node|Quintile    |Moon     |71.3480 |0.6520  
+Mean Node|SemiSextile |Mercury  |32.8520 |2.8520  
+Mean Node|Quintile    |Venus    |73.1216 |1.1216  
+Mean Node|SemiSquare  |Mars     |45.4177 |0.4177  
+Mean Node|Sextile     |Saturn   |61.2954 |1.2954  
+Mean Node|Sextile     |Uranus   |65.4414 |5.4414  
+Mean Node|Sextile     |Neptune  |57.3879 |2.6121  
+Mean Node|Trine       |Pluto    |112.8210|7.1790  
+Mean Node|Trine       |Chiron   |116.0108|3.9892  
+Lilith   |Square      |Moon     |89.8532 |0.1468  
+Lilith   |Trine       |Mercury  |128.3491|8.3491  
+Lilith   |Square      |Venus    |88.0796 |1.9204  
+Lilith   |Trine       |Jupiter  |119.8796|0.1204  
+Lilith   |Square      |Saturn   |99.9058 |9.9058  
+Lilith   |Square      |Uranus   |95.7597 |5.7597  
+Lilith   |Square      |Chiron   |82.7880 |7.2120  
+Chiron   |Opposition  |Moon     |187.3588|7.3588  
+Chiron   |Quincunx    |Mercury  |148.8628|1.1372  
+Chiron   |Opposition  |Venus    |189.1324|9.1324  
+Chiron   |Quintile    |Mars     |70.5932 |1.4068  
+Chiron   |Opposition  |Saturn   |177.3062|2.6938  
+Chiron   |Opposition  |Uranus   |181.4522|1.4522  
+Chiron   |Opposition  |Neptune  |173.3987|6.6013  
+Chiron   |Trine       |Mean Node|116.0108|3.9892  
+Chiron   |Square      |Lilith   |82.7880 |7.2120  
+
+Axes Aspects
+-----------------
+Aspecting|Aspect      |Aspected |Angle   |Orb     
+Sun      |Square      |Asc      |80.5098 |9.4902  
+Sun      |Opposition  |MC       |171.7742|8.2258  
+Moon     |Sextile     |Asc      |60.7476 |0.7476  
+Moon     |Quincunx    |MC       |152.0120|2.0120  
+Mercury  |Square      |Asc      |99.2435 |9.2435  
+Venus    |Sextile     |Asc      |58.9740 |1.0260  
+Venus    |Quincunx    |MC       |150.2384|0.2384  
+Mars     |Opposition  |Asc      |177.5132|2.4868  
+Mars     |Square      |MC       |91.2224 |1.2224  
+Jupiter  |Quincunx    |Asc      |148.9852|1.0148  
+Jupiter  |Sextile     |MC       |57.7208 |2.2792  
+Saturn   |Quintile    |Asc      |70.8002 |1.1998  
+Pluto    |Trine       |MC       |110.5390|9.4610  
+Mean Node|Sesquisquare|Asc      |132.0955|2.9045  
+Mean Node|Sesquisquare|MC       |136.6400|1.6400  
+Lilith   |SemiSextile |Asc      |29.1056 |0.8944  
+Lilith   |Sextile     |MC       |62.1588 |2.1588  
+Chiron   |Trine       |Asc      |111.8936|8.1064  

--- a/test/files/transitsText/golden
+++ b/test/files/transitsText/golden
@@ -8,7 +8,7 @@ Natal Planet Positions
 ----------------------
 Planet       |House|Longitude|Speed   |Latitude|Declination|Zodiac Longitude
 Sun          |3    |285.9234 |1.0197  |-0.0001 |-22.4930   |♑️ 15° 55' 24"
-Moon         |3    |266.1613 |13.6359 |-4.8030 |-28.1881   |♐️ 26° 9' 41"
+Moon         |3    |266.1612 |13.6359 |-4.8030 |-28.1881   |♐️ 26° 9' 40"
 Mercury      |4    |304.6572 |1.2569  |-1.3025 |-20.3661   |♒️ 4° 39' 26"
 Venus        |2    |264.3876 |1.2513  |0.5999  |-22.7245   |♐️ 24° 23' 15"
 Mars         |6    |22.9268  |0.5246  |0.6525  |9.5214     |♈️ 22° 55' 37"
@@ -44,7 +44,7 @@ Planetary Transits
 All Aspects to Natal Planets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Aspecting|Aspect      |Aspected |Angle   |Orb     |Phase
-Sun      |Conjunction |Moon     |4.5266  |4.5266  |Separating
+Sun      |Conjunction |Moon     |4.5267  |4.5267  |Separating
 Sun      |Conjunction |Venus    |6.3003  |6.3003  |Separating
 Sun      |Trine       |Mars     |112.2389|7.7611  |Applying
 Sun      |BiQuintile  |Jupiter  |145.7405|1.7405  |Separating
@@ -54,7 +54,7 @@ Sun      |Conjunction |Neptune  |9.4334  |9.4334  |Separating
 Sun      |SemiSquare  |Pluto    |45.9997 |0.9997  |Separating
 Sun      |Square      |Lilith   |94.3799 |4.3799  |Separating
 Sun      |Opposition  |Chiron   |177.1679|2.8321  |Applying
-Moon     |Square      |Moon     |95.7084 |5.7084  |Separating
+Moon     |Square      |Moon     |95.7085 |5.7085  |Separating
 Moon     |Sextile     |Mercury  |57.2126 |2.7874  |Applying
 Moon     |Square      |Venus    |97.4821 |7.4821  |Separating
 Moon     |Sextile     |Jupiter  |54.5587 |5.4413  |Applying
@@ -64,10 +64,10 @@ Moon     |Square      |Neptune  |81.7484 |8.2516  |Applying
 Moon     |Sesquisquare|Pluto    |137.1815|2.1815  |Separating
 Moon     |Opposition  |Lilith   |185.5617|5.5617  |Separating
 Moon     |Square      |Chiron   |91.6503 |1.6503  |Separating
-Mercury  |Conjunction |Moon     |5.6313  |5.6313  |Separating
+Mercury  |Conjunction |Moon     |5.6315  |5.6315  |Separating
 Mercury  |SemiSextile |Mercury  |32.8645 |2.8645  |Separating
 Mercury  |Conjunction |Venus    |7.4051  |7.4051  |Separating
-Mercury  |Trine       |Mars     |111.1342|8.8658  |Applying
+Mercury  |Trine       |Mars     |111.1341|8.8659  |Applying
 Mercury  |BiQuintile  |Jupiter  |144.6358|0.6358  |Separating
 Mercury  |Conjunction |Saturn   |4.4211  |4.4211  |Separating
 Mercury  |Conjunction |Uranus   |0.2751  |0.2751  |Separating
@@ -78,12 +78,12 @@ Mercury  |Square      |Lilith   |95.4847 |5.4847  |Separating
 Mercury  |Opposition  |Chiron   |178.2727|1.7273  |Applying
 Venus    |Sextile     |Mercury  |56.6428 |3.3572  |Applying
 Venus    |Sesquisquare|Mars     |134.9125|0.0875  |Applying
-Venus    |SemiSextile |Saturn   |28.1995 |1.8005  |Applying
+Venus    |SemiSextile |Saturn   |28.1994 |1.8006  |Applying
 Venus    |SemiSextile |Neptune  |32.1069 |2.1069  |Separating
 Venus    |Square      |Mean Node|89.4948 |0.5052  |Applying
 Venus    |Quintile    |Lilith   |71.7063 |0.2937  |Applying
 Mars     |Square      |Sun      |97.4128 |7.4128  |Separating
-Mars     |Trine       |Moon     |117.1748|2.8252  |Applying
+Mars     |Trine       |Moon     |117.1750|2.8250  |Applying
 Mars     |Trine       |Venus    |118.9486|1.0514  |Applying
 Mars     |Conjunction |Mars     |0.4094  |0.4094  |Separating
 Mars     |Trine       |Uranus   |111.2685|8.7315  |Applying
@@ -96,7 +96,7 @@ Jupiter  |Trine       |Jupiter  |115.8697|4.1303  |Applying
 Jupiter  |SemiSextile |Uranus   |28.4910 |1.5090  |Applying
 Jupiter  |Trine       |Lilith   |124.2507|4.2507  |Separating
 Jupiter  |Quincunx    |Chiron   |152.9613|2.9613  |Separating
-Saturn   |Conjunction |Mercury  |4.1354  |4.1354  |Separating
+Saturn   |Conjunction |Mercury  |4.1353  |4.1353  |Separating
 Saturn   |Square      |Mars     |82.4050 |7.5950  |Applying
 Saturn   |Trine       |Jupiter  |115.9066|4.0934  |Applying
 Saturn   |SemiSextile |Uranus   |28.4541 |1.5459  |Applying
@@ -112,25 +112,25 @@ Uranus   |Opposition  |Pluto    |172.2646|7.7354  |Separating
 Uranus   |Sextile     |Mean Node|59.4436 |0.5564  |Separating
 Uranus   |Sextile     |Chiron   |56.5672 |3.4328  |Separating
 Neptune  |Sextile     |Sun      |62.3926 |2.3926  |Separating
-Neptune  |Square      |Moon     |82.1546 |7.8454  |Applying
+Neptune  |Square      |Moon     |82.1548 |7.8452  |Applying
 Neptune  |SemiSquare  |Mercury  |43.6588 |1.3412  |Applying
 Neptune  |Square      |Venus    |83.9284 |6.0716  |Applying
 Neptune  |Quintile    |Saturn   |72.1022 |0.1022  |Separating
 Neptune  |Trine       |Pluto    |123.6278|3.6278  |Separating
 Neptune  |Opposition  |Lilith   |172.0080|7.9920  |Applying
 Pluto    |Conjunction |Sun      |7.9486  |7.9486  |Separating
-Pluto    |SemiSextile |Moon     |27.7106 |2.2894  |Applying
+Pluto    |SemiSextile |Moon     |27.7108 |2.2892  |Applying
 Pluto    |SemiSextile |Venus    |29.4844 |0.5156  |Applying
 Pluto    |Square      |Mars     |89.0548 |0.9452  |Applying
 Pluto    |Trine       |Jupiter  |122.5565|2.5565  |Separating
 Pluto    |SemiSquare  |Mean Node|43.6372 |1.3628  |Applying
 Pluto    |Trine       |Lilith   |117.5640|2.4360  |Applying
-Mean Node|Opposition  |Moon     |173.2213|6.7787  |Separating
+Mean Node|Opposition  |Moon     |173.2215|6.7785  |Separating
 Mean Node|Sesquisquare|Mercury  |134.7255|0.2745  |Separating
 Mean Node|Opposition  |Venus    |174.9951|5.0049  |Separating
-Mean Node|Sextile     |Mars     |56.4558 |3.5442  |Separating
+Mean Node|Sextile     |Mars     |56.4559 |3.5441  |Separating
 Mean Node|BiQuintile  |Pluto    |145.3055|1.3055  |Separating
-Mean Node|Square      |Lilith   |96.9254 |6.9254  |Separating
+Mean Node|Square      |Lilith   |96.9253 |6.9253  |Separating
 Lilith   |Trine       |Sun      |110.9572|9.0428  |Applying
 Lilith   |Square      |Mercury  |92.2234 |2.2234  |Separating
 Lilith   |Sesquisquare|Venus    |132.4930|2.5070  |Applying
@@ -140,7 +140,7 @@ Lilith   |Trine       |Neptune  |116.7593|3.2407  |Applying
 Lilith   |Opposition  |Pluto    |172.1924|7.8076  |Applying
 Lilith   |Sextile     |Mean Node|59.3714 |0.6286  |Applying
 Lilith   |Sextile     |Chiron   |56.6394 |3.3606  |Applying
-Chiron   |Square      |Moon     |98.7970 |8.7970  |Separating
+Chiron   |Square      |Moon     |98.7972 |8.7972  |Separating
 Chiron   |Sextile     |Mercury  |60.3012 |0.3012  |Separating
 Chiron   |Square      |Saturn   |88.7445 |1.2555  |Applying
 Chiron   |Square      |Uranus   |92.8906 |2.8906  |Separating
@@ -196,29 +196,29 @@ Axes Transits
 All Aspects to Natal Axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Aspecting|Aspect      |Aspected |Angle   |Orb     |Phase
-Sun      |Sextile     |Asc      |65.2703 |5.2703  |Separating
-Moon     |Trine       |MC       |112.2834|7.7166  |Applying
-Venus    |SemiSquare  |Asc      |42.5967 |2.4033  |Applying
-Venus    |Sesquisquare|MC       |133.8612|1.1388  |Applying
-Mars     |Opposition  |Asc      |177.9186|2.0814  |Applying
-Mars     |Square      |MC       |90.8170 |0.8170  |Separating
-Jupiter  |Square      |Asc      |95.1411 |5.1411  |Separating
-Jupiter  |Opposition  |MC       |186.4056|6.4056  |Separating
-Saturn   |Square      |Asc      |95.1042 |5.1042  |Separating
-Saturn   |Opposition  |MC       |186.3687|6.3687  |Separating
-Neptune  |BiQuintile  |Asc      |142.8983|1.1017  |Applying
-Neptune  |Trine       |MC       |125.8372|5.8372  |Separating
-Pluto    |Square      |Asc      |88.4543 |1.5457  |Applying
-Pluto    |Opposition  |MC       |179.7188|0.2812  |Applying
-Mean Node|Trine       |Asc      |126.0350|6.0350  |Separating
+Sun      |Sextile     |Asc      |65.2743 |5.2743  |Separating
+Moon     |Trine       |MC       |112.2795|7.7205  |Applying
+Venus    |SemiSquare  |Asc      |42.6007 |2.3993  |Applying
+Venus    |Sesquisquare|MC       |133.8651|1.1349  |Applying
+Mars     |Opposition  |Asc      |177.9226|2.0774  |Applying
+Mars     |Square      |MC       |90.8130 |0.8130  |Separating
+Jupiter  |Square      |Asc      |95.1451 |5.1451  |Separating
+Jupiter  |Opposition  |MC       |186.4095|6.4095  |Separating
+Saturn   |Square      |Asc      |95.1082 |5.1082  |Separating
+Saturn   |Opposition  |MC       |186.3726|6.3726  |Separating
+Neptune  |BiQuintile  |Asc      |142.9023|1.0977  |Applying
+Neptune  |Trine       |MC       |125.8332|5.8332  |Separating
+Pluto    |Square      |Asc      |88.4584 |1.5416  |Applying
+Pluto    |Opposition  |MC       |179.7228|0.2772  |Applying
+Mean Node|Trine       |Asc      |126.0310|6.0310  |Separating
 
 Active Transits to Natal Axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Transiting|Aspect      |Transited|Starts                  |Ends                    |Exact At                
-Moon      |Trine       |MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-22 17:39:41 UTC 
-Venus     |Sesquisquare|MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-23 00:06:15 UTC 
+Moon      |Trine       |MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-22 17:40:10 UTC 
+Venus     |Sesquisquare|MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-23 00:01:42 UTC 
 Mars      |Opposition  |Asc      |2020-08-18 00:00:00 UTC |2020-12-29 00:00:00 UTC |N/A                     
-Neptune   |BiQuintile  |Asc      |2019-05-19 00:00:00 UTC |2021-12-08 00:00:00 UTC |N/A                     
-Pluto     |Square      |Asc      |2020-03-08 00:00:00 UTC |2022-11-13 00:00:00 UTC |N/A                     
-Pluto     |Opposition  |MC       |2020-01-24 00:00:00 UTC |2021-12-05 00:00:00 UTC |N/A                     
+Neptune   |BiQuintile  |Asc      |2019-05-19 00:00:00 UTC |2021-12-07 00:00:00 UTC |N/A                     
+Pluto     |Square      |Asc      |2020-03-08 00:00:00 UTC |2022-11-12 00:00:00 UTC |N/A                     
+Pluto     |Opposition  |MC       |2019-04-22 00:00:00 UTC |2021-12-05 00:00:00 UTC |N/A                     
 

--- a/test/files/transitsText/golden
+++ b/test/files/transitsText/golden
@@ -46,41 +46,41 @@ All Aspects to Natal Planets
 Aspecting|Aspect      |Aspected |Angle   |Orb     |Phase
 Sun      |Conjunction |Moon     |4.5267  |4.5267  |Separating
 Sun      |Conjunction |Venus    |6.3003  |6.3003  |Separating
-Sun      |Trine       |Mars     |112.2389|7.7611  |Applying
-Sun      |BiQuintile  |Jupiter  |145.7405|1.7405  |Separating
-Sun      |Conjunction |Saturn   |5.5259  |5.5259  |Separating
-Sun      |Conjunction |Uranus   |1.3798  |1.3798  |Separating
-Sun      |Conjunction |Neptune  |9.4334  |9.4334  |Separating
+Sun      |Trine       |Mars     |112.2389|7.7611  |Separating
+Sun      |BiQuintile  |Jupiter  |145.7405|1.7405  |Applying
+Sun      |Conjunction |Saturn   |5.5259  |5.5259  |Applying
+Sun      |Conjunction |Uranus   |1.3798  |1.3798  |Applying
+Sun      |Conjunction |Neptune  |9.4334  |9.4334  |Applying
 Sun      |SemiSquare  |Pluto    |45.9997 |0.9997  |Separating
 Sun      |Square      |Lilith   |94.3799 |4.3799  |Separating
 Sun      |Opposition  |Chiron   |177.1679|2.8321  |Applying
 Moon     |Square      |Moon     |95.7085 |5.7085  |Separating
 Moon     |Sextile     |Mercury  |57.2126 |2.7874  |Applying
 Moon     |Square      |Venus    |97.4821 |7.4821  |Separating
-Moon     |Sextile     |Jupiter  |54.5587 |5.4413  |Applying
+Moon     |Sextile     |Jupiter  |54.5587 |5.4413  |Separating
 Moon     |Square      |Saturn   |85.6559 |4.3441  |Applying
 Moon     |Square      |Uranus   |89.8020 |0.1980  |Applying
 Moon     |Square      |Neptune  |81.7484 |8.2516  |Applying
 Moon     |Sesquisquare|Pluto    |137.1815|2.1815  |Separating
-Moon     |Opposition  |Lilith   |185.5617|5.5617  |Separating
-Moon     |Square      |Chiron   |91.6503 |1.6503  |Separating
+Moon     |Opposition  |Lilith   |174.4383|5.5617  |Separating
+Moon     |Square      |Chiron   |91.6503 |1.6503  |Applying
 Mercury  |Conjunction |Moon     |5.6315  |5.6315  |Separating
-Mercury  |SemiSextile |Mercury  |32.8645 |2.8645  |Separating
+Mercury  |SemiSextile |Mercury  |32.8645 |2.8645  |Applying
 Mercury  |Conjunction |Venus    |7.4051  |7.4051  |Separating
-Mercury  |Trine       |Mars     |111.1341|8.8659  |Applying
-Mercury  |BiQuintile  |Jupiter  |144.6358|0.6358  |Separating
-Mercury  |Conjunction |Saturn   |4.4211  |4.4211  |Separating
-Mercury  |Conjunction |Uranus   |0.2751  |0.2751  |Separating
-Mercury  |Conjunction |Neptune  |8.3286  |8.3286  |Separating
+Mercury  |Trine       |Mars     |111.1341|8.8659  |Separating
+Mercury  |BiQuintile  |Jupiter  |144.6358|0.6358  |Applying
+Mercury  |Conjunction |Saturn   |4.4211  |4.4211  |Applying
+Mercury  |Conjunction |Uranus   |0.2751  |0.2751  |Applying
+Mercury  |Conjunction |Neptune  |8.3286  |8.3286  |Applying
 Mercury  |SemiSquare  |Pluto    |47.1045 |2.1045  |Separating
-Mercury  |Sextile     |Mean Node|65.7165 |5.7165  |Separating
+Mercury  |Sextile     |Mean Node|65.7165 |5.7165  |Applying
 Mercury  |Square      |Lilith   |95.4847 |5.4847  |Separating
 Mercury  |Opposition  |Chiron   |178.2727|1.7273  |Applying
-Venus    |Sextile     |Mercury  |56.6428 |3.3572  |Applying
-Venus    |Sesquisquare|Mars     |134.9125|0.0875  |Applying
-Venus    |SemiSextile |Saturn   |28.1994 |1.8006  |Applying
-Venus    |SemiSextile |Neptune  |32.1069 |2.1069  |Separating
-Venus    |Square      |Mean Node|89.4948 |0.5052  |Applying
+Venus    |Sextile     |Mercury  |56.6428 |3.3572  |Separating
+Venus    |Sesquisquare|Mars     |134.9125|0.0875  |Separating
+Venus    |SemiSextile |Saturn   |28.1994 |1.8006  |Separating
+Venus    |SemiSextile |Neptune  |32.1069 |2.1069  |Applying
+Venus    |Square      |Mean Node|89.4948 |0.5052  |Separating
 Venus    |Quintile    |Lilith   |71.7063 |0.2937  |Applying
 Mars     |Square      |Sun      |97.4128 |7.4128  |Separating
 Mars     |Trine       |Moon     |117.1750|2.8250  |Applying
@@ -88,29 +88,29 @@ Mars     |Trine       |Venus    |118.9486|1.0514  |Applying
 Mars     |Conjunction |Mars     |0.4094  |0.4094  |Separating
 Mars     |Trine       |Uranus   |111.2685|8.7315  |Applying
 Mars     |SemiSquare  |Mean Node|45.8270 |0.8270  |Separating
-Mars     |Quincunx    |Lilith   |152.9718|2.9718  |Separating
-Mars     |Quintile    |Chiron   |70.1838 |1.8162  |Applying
-Jupiter  |Conjunction |Mercury  |4.0985  |4.0985  |Separating
-Jupiter  |Square      |Mars     |82.3681 |7.6319  |Applying
-Jupiter  |Trine       |Jupiter  |115.8697|4.1303  |Applying
+Mars     |Quincunx    |Lilith   |152.9718|2.9718  |Applying
+Mars     |Quintile    |Chiron   |70.1838 |1.8162  |Separating
+Jupiter  |Conjunction |Mercury  |4.0985  |4.0985  |Applying
+Jupiter  |Square      |Mars     |82.3681 |7.6319  |Separating
+Jupiter  |Trine       |Jupiter  |115.8697|4.1303  |Separating
 Jupiter  |SemiSextile |Uranus   |28.4910 |1.5090  |Applying
 Jupiter  |Trine       |Lilith   |124.2507|4.2507  |Separating
-Jupiter  |Quincunx    |Chiron   |152.9613|2.9613  |Separating
-Saturn   |Conjunction |Mercury  |4.1353  |4.1353  |Separating
-Saturn   |Square      |Mars     |82.4050 |7.5950  |Applying
-Saturn   |Trine       |Jupiter  |115.9066|4.0934  |Applying
+Jupiter  |Quincunx    |Chiron   |152.9613|2.9613  |Applying
+Saturn   |Conjunction |Mercury  |4.1353  |4.1353  |Applying
+Saturn   |Square      |Mars     |82.4050 |7.5950  |Separating
+Saturn   |Trine       |Jupiter  |115.9066|4.0934  |Separating
 Saturn   |SemiSextile |Uranus   |28.4541 |1.5459  |Applying
 Saturn   |Trine       |Lilith   |124.2138|4.2138  |Separating
-Saturn   |Quincunx    |Chiron   |152.9982|2.9982  |Separating
+Saturn   |Quincunx    |Chiron   |152.9982|2.9982  |Applying
 Uranus   |Trine       |Sun      |111.0294|8.9706  |Separating
-Uranus   |Square      |Mercury  |92.2956 |2.2956  |Separating
+Uranus   |Square      |Mercury  |92.2956 |2.2956  |Applying
 Uranus   |Sesquisquare|Venus    |132.5652|2.4348  |Separating
-Uranus   |Trine       |Saturn   |120.7390|0.7390  |Separating
-Uranus   |Trine       |Uranus   |124.8850|4.8850  |Separating
+Uranus   |Trine       |Saturn   |120.7390|0.7390  |Applying
+Uranus   |Trine       |Uranus   |124.8850|4.8850  |Applying
 Uranus   |Trine       |Neptune  |116.8315|3.1685  |Separating
-Uranus   |Opposition  |Pluto    |172.2646|7.7354  |Separating
+Uranus   |Opposition  |Pluto    |187.7354|7.7354  |Separating
 Uranus   |Sextile     |Mean Node|59.4436 |0.5564  |Separating
-Uranus   |Sextile     |Chiron   |56.5672 |3.4328  |Separating
+Uranus   |Sextile     |Chiron   |56.5672 |3.4328  |Applying
 Neptune  |Sextile     |Sun      |62.3926 |2.3926  |Separating
 Neptune  |Square      |Moon     |82.1548 |7.8452  |Applying
 Neptune  |SemiSquare  |Mercury  |43.6588 |1.3412  |Applying
@@ -121,74 +121,66 @@ Neptune  |Opposition  |Lilith   |172.0080|7.9920  |Applying
 Pluto    |Conjunction |Sun      |7.9486  |7.9486  |Separating
 Pluto    |SemiSextile |Moon     |27.7108 |2.2892  |Applying
 Pluto    |SemiSextile |Venus    |29.4844 |0.5156  |Applying
-Pluto    |Square      |Mars     |89.0548 |0.9452  |Applying
-Pluto    |Trine       |Jupiter  |122.5565|2.5565  |Separating
-Pluto    |SemiSquare  |Mean Node|43.6372 |1.3628  |Applying
+Pluto    |Square      |Mars     |89.0548 |0.9452  |Separating
+Pluto    |Trine       |Jupiter  |122.5565|2.5565  |Applying
+Pluto    |SemiSquare  |Mean Node|43.6372 |1.3628  |Separating
 Pluto    |Trine       |Lilith   |117.5640|2.4360  |Applying
-Mean Node|Opposition  |Moon     |173.2215|6.7785  |Separating
-Mean Node|Sesquisquare|Mercury  |134.7255|0.2745  |Separating
-Mean Node|Opposition  |Venus    |174.9951|5.0049  |Separating
-Mean Node|Sextile     |Mars     |56.4559 |3.5441  |Separating
-Mean Node|BiQuintile  |Pluto    |145.3055|1.3055  |Separating
-Mean Node|Square      |Lilith   |96.9253 |6.9253  |Separating
+Mean Node|Opposition  |Moon     |186.7785|6.7785  |Applying
+Mean Node|Sesquisquare|Mercury  |134.7255|0.2745  |Applying
+Mean Node|Opposition  |Venus    |185.0049|5.0049  |Applying
+Mean Node|Sextile     |Mars     |56.4559 |3.5441  |Applying
+Mean Node|BiQuintile  |Pluto    |145.3055|1.3055  |Applying
+Mean Node|Square      |Lilith   |96.9253 |6.9253  |Applying
 Lilith   |Trine       |Sun      |110.9572|9.0428  |Applying
 Lilith   |Square      |Mercury  |92.2234 |2.2234  |Separating
 Lilith   |Sesquisquare|Venus    |132.4930|2.5070  |Applying
 Lilith   |Trine       |Saturn   |120.6668|0.6668  |Separating
 Lilith   |Trine       |Uranus   |124.8129|4.8129  |Separating
 Lilith   |Trine       |Neptune  |116.7593|3.2407  |Applying
-Lilith   |Opposition  |Pluto    |172.1924|7.8076  |Applying
+Lilith   |Opposition  |Pluto    |187.8076|7.8076  |Applying
 Lilith   |Sextile     |Mean Node|59.3714 |0.6286  |Applying
-Lilith   |Sextile     |Chiron   |56.6394 |3.3606  |Applying
+Lilith   |Sextile     |Chiron   |56.6394 |3.3606  |Separating
 Chiron   |Square      |Moon     |98.7972 |8.7972  |Separating
 Chiron   |Sextile     |Mercury  |60.3012 |0.3012  |Separating
 Chiron   |Square      |Saturn   |88.7445 |1.2555  |Applying
 Chiron   |Square      |Uranus   |92.8906 |2.8906  |Separating
 Chiron   |Square      |Neptune  |84.8371 |5.1629  |Applying
 Chiron   |SemiSextile |Mean Node|27.4492 |2.5508  |Applying
-Chiron   |Opposition  |Lilith   |188.6503|8.6503  |Separating
-Chiron   |Square      |Chiron   |88.5616 |1.4384  |Applying
+Chiron   |Opposition  |Lilith   |171.3497|8.6503  |Separating
+Chiron   |Square      |Chiron   |88.5616 |1.4384  |Separating
 
 Active Transits to Natal Planets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Transiting|Aspect      |Transited|Starts                  |Ends                    |Exact At                
 Moon      |Sextile     |Mercury  |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 07:47:59 UTC 
-Moon      |Sextile     |Jupiter  |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 13:06:08 UTC 
 Moon      |Square      |Saturn   |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 10:54:29 UTC 
 Moon      |Square      |Uranus   |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 02:38:35 UTC 
 Moon      |Square      |Neptune  |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-22 18:44:06 UTC 
-Moon      |Sesquisquare|Pluto    |N/A                     |2020-12-23 00:00:00 UTC |N/A                     
-Moon      |Square      |Chiron   |N/A                     |2020-12-23 00:00:00 UTC |N/A                     
-Mercury   |BiQuintile  |Jupiter  |2020-12-21 00:00:00 UTC |2020-12-23 00:00:00 UTC |N/A                     
-Mercury   |Conjunction |Uranus   |2020-12-21 00:00:00 UTC |2020-12-23 00:00:00 UTC |N/A                     
+Moon      |Square      |Chiron   |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 05:31:59 UTC 
+Mercury   |BiQuintile  |Jupiter  |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 11:51:17 UTC 
+Mercury   |Conjunction |Uranus   |2020-12-21 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 06:24:23 UTC 
 Mercury   |Opposition  |Chiron   |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-23 04:19:34 UTC 
-Venus     |Sesquisquare|Mars     |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 03:55:45 UTC 
-Venus     |Square      |Mean Node|2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 11:56:41 UTC 
+Venus     |Sesquisquare|Mars     |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 00:34:10 UTC 
 Venus     |Quintile    |Lilith   |2020-12-22 00:00:00 UTC |2020-12-23 00:00:00 UTC |2020-12-22 07:53:08 UTC 
 Mars      |Trine       |Moon     |2020-08-21 00:00:00 UTC |2020-12-31 00:00:00 UTC |N/A                     
 Mars      |Trine       |Venus    |2020-08-15 00:00:00 UTC |2020-12-27 00:00:00 UTC |N/A                     
 Mars      |Conjunction |Mars     |2020-08-11 00:00:00 UTC |2020-12-23 00:00:00 UTC |N/A                     
-Mars      |Quintile    |Chiron   |2020-08-17 00:00:00 UTC |2020-12-29 00:00:00 UTC |N/A                     
+Mars      |Quincunx    |Lilith   |2020-08-21 00:00:00 UTC |2020-12-31 00:00:00 UTC |N/A                     
 Saturn    |SemiSextile |Uranus   |2020-04-08 00:00:00 UTC |2021-01-13 00:00:00 UTC |N/A                     
 Uranus    |Sesquisquare|Venus    |2020-05-29 00:00:00 UTC |2021-04-25 00:00:00 UTC |N/A                     
 Uranus    |Trine       |Saturn   |2019-06-13 00:00:00 UTC |2021-02-17 00:00:00 UTC |N/A                     
 Uranus    |Trine       |Neptune  |2020-06-13 00:00:00 UTC |2022-02-14 00:00:00 UTC |N/A                     
 Uranus    |Sextile     |Mean Node|2019-07-28 00:00:00 UTC |2021-03-22 00:00:00 UTC |N/A                     
-Uranus    |Sextile     |Chiron   |2020-06-19 00:00:00 UTC |2022-02-24 00:00:00 UTC |N/A                     
 Neptune   |SemiSquare  |Mercury  |2019-06-06 00:00:00 UTC |2021-12-31 00:00:00 UTC |N/A                     
 Neptune   |Quintile    |Saturn   |2019-04-05 00:00:00 UTC |2021-01-30 00:00:00 UTC |N/A                     
 Pluto     |SemiSextile |Venus    |2020-02-01 00:00:00 UTC |2021-12-14 00:00:00 UTC |N/A                     
-Pluto     |Square      |Mars     |2020-02-14 00:00:00 UTC |2021-12-28 00:00:00 UTC |N/A                     
-Pluto     |SemiSquare  |Mean Node|2020-03-01 00:00:00 UTC |2022-10-30 00:00:00 UTC |N/A                     
+Pluto     |Square      |Mars     |2019-02-11 00:00:00 UTC |2020-12-23 00:00:00 UTC |N/A                     
 Lilith    |Trine       |Saturn   |2020-12-08 00:00:00 UTC |2020-12-25 00:00:00 UTC |N/A                     
 Lilith    |Sextile     |Mean Node|2020-12-19 00:00:00 UTC |2021-01-05 00:00:00 UTC |N/A                     
-Chiron    |Square      |Moon     |N/A                     |N/A                     |N/A                     
 Chiron    |Sextile     |Mercury  |2019-04-24 00:00:00 UTC |2021-01-25 00:00:00 UTC |N/A                     
 Chiron    |Square      |Saturn   |2019-05-29 00:00:00 UTC |2021-02-28 00:00:00 UTC |N/A                     
 Chiron    |Square      |Neptune  |2020-06-15 00:00:00 UTC |2022-03-11 00:00:00 UTC |N/A                     
 Chiron    |SemiSextile |Mean Node|2020-04-15 00:00:00 UTC |2022-01-01 00:00:00 UTC |N/A                     
-Chiron    |Opposition  |Lilith   |N/A                     |N/A                     |N/A                     
-Chiron    |Square      |Chiron   |2019-06-04 00:00:00 UTC |2021-03-03 00:00:00 UTC |N/A                     
 
 Axes Transits
 -------------
@@ -197,27 +189,27 @@ All Aspects to Natal Axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Aspecting|Aspect      |Aspected |Angle   |Orb     |Phase
 Sun      |Sextile     |Asc      |65.2743 |5.2743  |Separating
-Moon     |Trine       |MC       |112.2795|7.7205  |Applying
+Moon     |Trine       |MC       |112.2795|7.7205  |Separating
 Venus    |SemiSquare  |Asc      |42.6007 |2.3993  |Applying
 Venus    |Sesquisquare|MC       |133.8651|1.1349  |Applying
-Mars     |Opposition  |Asc      |177.9226|2.0774  |Applying
-Mars     |Square      |MC       |90.8130 |0.8130  |Separating
+Mars     |Opposition  |Asc      |182.0774|2.0774  |Applying
+Mars     |Square      |MC       |90.8130 |0.8130  |Applying
 Jupiter  |Square      |Asc      |95.1451 |5.1451  |Separating
 Jupiter  |Opposition  |MC       |186.4095|6.4095  |Separating
 Saturn   |Square      |Asc      |95.1082 |5.1082  |Separating
 Saturn   |Opposition  |MC       |186.3726|6.3726  |Separating
 Neptune  |BiQuintile  |Asc      |142.9023|1.0977  |Applying
-Neptune  |Trine       |MC       |125.8332|5.8332  |Separating
+Neptune  |Trine       |MC       |125.8332|5.8332  |Applying
 Pluto    |Square      |Asc      |88.4584 |1.5416  |Applying
 Pluto    |Opposition  |MC       |179.7228|0.2772  |Applying
-Mean Node|Trine       |Asc      |126.0310|6.0310  |Separating
+Mean Node|Trine       |Asc      |126.0310|6.0310  |Applying
 
 Active Transits to Natal Axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Transiting|Aspect      |Transited|Starts                  |Ends                    |Exact At                
-Moon      |Trine       |MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-22 17:40:10 UTC 
 Venus     |Sesquisquare|MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-23 00:01:42 UTC 
 Mars      |Opposition  |Asc      |2020-08-18 00:00:00 UTC |2020-12-29 00:00:00 UTC |N/A                     
+Mars      |Square      |MC       |2020-08-14 00:00:00 UTC |2020-12-26 00:00:00 UTC |N/A                     
 Neptune   |BiQuintile  |Asc      |2019-05-19 00:00:00 UTC |2021-12-07 00:00:00 UTC |N/A                     
 Pluto     |Square      |Asc      |2020-03-08 00:00:00 UTC |2022-11-12 00:00:00 UTC |N/A                     
 Pluto     |Opposition  |MC       |2019-04-22 00:00:00 UTC |2021-12-05 00:00:00 UTC |N/A                     

--- a/test/files/transitsText/golden
+++ b/test/files/transitsText/golden
@@ -8,7 +8,7 @@ Natal Planet Positions
 ----------------------
 Planet       |House|Longitude|Speed   |Latitude|Declination|Zodiac Longitude
 Sun          |3    |285.9234 |1.0197  |-0.0001 |-22.4930   |♑️ 15° 55' 24"
-Moon         |3    |266.1612 |13.6359 |-4.8030 |-28.1881   |♐️ 26° 9' 40"
+Moon         |3    |266.1613 |13.6359 |-4.8030 |-28.1881   |♐️ 26° 9' 41"
 Mercury      |4    |304.6572 |1.2569  |-1.3025 |-20.3661   |♒️ 4° 39' 26"
 Venus        |2    |264.3876 |1.2513  |0.5999  |-22.7245   |♐️ 24° 23' 15"
 Mars         |6    |22.9268  |0.5246  |0.6525  |9.5214     |♈️ 22° 55' 37"
@@ -44,7 +44,7 @@ Planetary Transits
 All Aspects to Natal Planets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Aspecting|Aspect      |Aspected |Angle   |Orb     |Phase
-Sun      |Conjunction |Moon     |4.5267  |4.5267  |Separating
+Sun      |Conjunction |Moon     |4.5266  |4.5266  |Separating
 Sun      |Conjunction |Venus    |6.3003  |6.3003  |Separating
 Sun      |Trine       |Mars     |112.2389|7.7611  |Applying
 Sun      |BiQuintile  |Jupiter  |145.7405|1.7405  |Separating
@@ -54,7 +54,7 @@ Sun      |Conjunction |Neptune  |9.4334  |9.4334  |Separating
 Sun      |SemiSquare  |Pluto    |45.9997 |0.9997  |Separating
 Sun      |Square      |Lilith   |94.3799 |4.3799  |Separating
 Sun      |Opposition  |Chiron   |177.1679|2.8321  |Applying
-Moon     |Square      |Moon     |95.7085 |5.7085  |Separating
+Moon     |Square      |Moon     |95.7084 |5.7084  |Separating
 Moon     |Sextile     |Mercury  |57.2126 |2.7874  |Applying
 Moon     |Square      |Venus    |97.4821 |7.4821  |Separating
 Moon     |Sextile     |Jupiter  |54.5587 |5.4413  |Applying
@@ -64,10 +64,10 @@ Moon     |Square      |Neptune  |81.7484 |8.2516  |Applying
 Moon     |Sesquisquare|Pluto    |137.1815|2.1815  |Separating
 Moon     |Opposition  |Lilith   |185.5617|5.5617  |Separating
 Moon     |Square      |Chiron   |91.6503 |1.6503  |Separating
-Mercury  |Conjunction |Moon     |5.6315  |5.6315  |Separating
+Mercury  |Conjunction |Moon     |5.6313  |5.6313  |Separating
 Mercury  |SemiSextile |Mercury  |32.8645 |2.8645  |Separating
 Mercury  |Conjunction |Venus    |7.4051  |7.4051  |Separating
-Mercury  |Trine       |Mars     |111.1341|8.8659  |Applying
+Mercury  |Trine       |Mars     |111.1342|8.8658  |Applying
 Mercury  |BiQuintile  |Jupiter  |144.6358|0.6358  |Separating
 Mercury  |Conjunction |Saturn   |4.4211  |4.4211  |Separating
 Mercury  |Conjunction |Uranus   |0.2751  |0.2751  |Separating
@@ -78,12 +78,12 @@ Mercury  |Square      |Lilith   |95.4847 |5.4847  |Separating
 Mercury  |Opposition  |Chiron   |178.2727|1.7273  |Applying
 Venus    |Sextile     |Mercury  |56.6428 |3.3572  |Applying
 Venus    |Sesquisquare|Mars     |134.9125|0.0875  |Applying
-Venus    |SemiSextile |Saturn   |28.1994 |1.8006  |Applying
+Venus    |SemiSextile |Saturn   |28.1995 |1.8005  |Applying
 Venus    |SemiSextile |Neptune  |32.1069 |2.1069  |Separating
 Venus    |Square      |Mean Node|89.4948 |0.5052  |Applying
 Venus    |Quintile    |Lilith   |71.7063 |0.2937  |Applying
 Mars     |Square      |Sun      |97.4128 |7.4128  |Separating
-Mars     |Trine       |Moon     |117.1750|2.8250  |Applying
+Mars     |Trine       |Moon     |117.1748|2.8252  |Applying
 Mars     |Trine       |Venus    |118.9486|1.0514  |Applying
 Mars     |Conjunction |Mars     |0.4094  |0.4094  |Separating
 Mars     |Trine       |Uranus   |111.2685|8.7315  |Applying
@@ -96,7 +96,7 @@ Jupiter  |Trine       |Jupiter  |115.8697|4.1303  |Applying
 Jupiter  |SemiSextile |Uranus   |28.4910 |1.5090  |Applying
 Jupiter  |Trine       |Lilith   |124.2507|4.2507  |Separating
 Jupiter  |Quincunx    |Chiron   |152.9613|2.9613  |Separating
-Saturn   |Conjunction |Mercury  |4.1353  |4.1353  |Separating
+Saturn   |Conjunction |Mercury  |4.1354  |4.1354  |Separating
 Saturn   |Square      |Mars     |82.4050 |7.5950  |Applying
 Saturn   |Trine       |Jupiter  |115.9066|4.0934  |Applying
 Saturn   |SemiSextile |Uranus   |28.4541 |1.5459  |Applying
@@ -112,25 +112,25 @@ Uranus   |Opposition  |Pluto    |172.2646|7.7354  |Separating
 Uranus   |Sextile     |Mean Node|59.4436 |0.5564  |Separating
 Uranus   |Sextile     |Chiron   |56.5672 |3.4328  |Separating
 Neptune  |Sextile     |Sun      |62.3926 |2.3926  |Separating
-Neptune  |Square      |Moon     |82.1548 |7.8452  |Applying
+Neptune  |Square      |Moon     |82.1546 |7.8454  |Applying
 Neptune  |SemiSquare  |Mercury  |43.6588 |1.3412  |Applying
 Neptune  |Square      |Venus    |83.9284 |6.0716  |Applying
 Neptune  |Quintile    |Saturn   |72.1022 |0.1022  |Separating
 Neptune  |Trine       |Pluto    |123.6278|3.6278  |Separating
 Neptune  |Opposition  |Lilith   |172.0080|7.9920  |Applying
 Pluto    |Conjunction |Sun      |7.9486  |7.9486  |Separating
-Pluto    |SemiSextile |Moon     |27.7108 |2.2892  |Applying
+Pluto    |SemiSextile |Moon     |27.7106 |2.2894  |Applying
 Pluto    |SemiSextile |Venus    |29.4844 |0.5156  |Applying
 Pluto    |Square      |Mars     |89.0548 |0.9452  |Applying
 Pluto    |Trine       |Jupiter  |122.5565|2.5565  |Separating
 Pluto    |SemiSquare  |Mean Node|43.6372 |1.3628  |Applying
 Pluto    |Trine       |Lilith   |117.5640|2.4360  |Applying
-Mean Node|Opposition  |Moon     |173.2215|6.7785  |Separating
+Mean Node|Opposition  |Moon     |173.2213|6.7787  |Separating
 Mean Node|Sesquisquare|Mercury  |134.7255|0.2745  |Separating
 Mean Node|Opposition  |Venus    |174.9951|5.0049  |Separating
-Mean Node|Sextile     |Mars     |56.4559 |3.5441  |Separating
+Mean Node|Sextile     |Mars     |56.4558 |3.5442  |Separating
 Mean Node|BiQuintile  |Pluto    |145.3055|1.3055  |Separating
-Mean Node|Square      |Lilith   |96.9253 |6.9253  |Separating
+Mean Node|Square      |Lilith   |96.9254 |6.9254  |Separating
 Lilith   |Trine       |Sun      |110.9572|9.0428  |Applying
 Lilith   |Square      |Mercury  |92.2234 |2.2234  |Separating
 Lilith   |Sesquisquare|Venus    |132.4930|2.5070  |Applying
@@ -140,7 +140,7 @@ Lilith   |Trine       |Neptune  |116.7593|3.2407  |Applying
 Lilith   |Opposition  |Pluto    |172.1924|7.8076  |Applying
 Lilith   |Sextile     |Mean Node|59.3714 |0.6286  |Applying
 Lilith   |Sextile     |Chiron   |56.6394 |3.3606  |Applying
-Chiron   |Square      |Moon     |98.7972 |8.7972  |Separating
+Chiron   |Square      |Moon     |98.7970 |8.7970  |Separating
 Chiron   |Sextile     |Mercury  |60.3012 |0.3012  |Separating
 Chiron   |Square      |Saturn   |88.7445 |1.2555  |Applying
 Chiron   |Square      |Uranus   |92.8906 |2.8906  |Separating
@@ -196,29 +196,29 @@ Axes Transits
 All Aspects to Natal Axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Aspecting|Aspect      |Aspected |Angle   |Orb     |Phase
-Sun      |Sextile     |Asc      |65.2743 |5.2743  |Separating
-Moon     |Trine       |MC       |112.2795|7.7205  |Applying
-Venus    |SemiSquare  |Asc      |42.6007 |2.3993  |Applying
-Venus    |Sesquisquare|MC       |133.8651|1.1349  |Applying
-Mars     |Opposition  |Asc      |177.9226|2.0774  |Applying
-Mars     |Square      |MC       |90.8130 |0.8130  |Separating
-Jupiter  |Square      |Asc      |95.1451 |5.1451  |Separating
-Jupiter  |Opposition  |MC       |186.4095|6.4095  |Separating
-Saturn   |Square      |Asc      |95.1082 |5.1082  |Separating
-Saturn   |Opposition  |MC       |186.3726|6.3726  |Separating
-Neptune  |BiQuintile  |Asc      |142.9023|1.0977  |Applying
-Neptune  |Trine       |MC       |125.8332|5.8332  |Separating
-Pluto    |Square      |Asc      |88.4584 |1.5416  |Applying
-Pluto    |Opposition  |MC       |179.7228|0.2772  |Applying
-Mean Node|Trine       |Asc      |126.0310|6.0310  |Separating
+Sun      |Sextile     |Asc      |65.2703 |5.2703  |Separating
+Moon     |Trine       |MC       |112.2834|7.7166  |Applying
+Venus    |SemiSquare  |Asc      |42.5967 |2.4033  |Applying
+Venus    |Sesquisquare|MC       |133.8612|1.1388  |Applying
+Mars     |Opposition  |Asc      |177.9186|2.0814  |Applying
+Mars     |Square      |MC       |90.8170 |0.8170  |Separating
+Jupiter  |Square      |Asc      |95.1411 |5.1411  |Separating
+Jupiter  |Opposition  |MC       |186.4056|6.4056  |Separating
+Saturn   |Square      |Asc      |95.1042 |5.1042  |Separating
+Saturn   |Opposition  |MC       |186.3687|6.3687  |Separating
+Neptune  |BiQuintile  |Asc      |142.8983|1.1017  |Applying
+Neptune  |Trine       |MC       |125.8372|5.8372  |Separating
+Pluto    |Square      |Asc      |88.4543 |1.5457  |Applying
+Pluto    |Opposition  |MC       |179.7188|0.2812  |Applying
+Mean Node|Trine       |Asc      |126.0350|6.0350  |Separating
 
 Active Transits to Natal Axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Transiting|Aspect      |Transited|Starts                  |Ends                    |Exact At                
-Moon      |Trine       |MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-22 17:40:10 UTC 
-Venus     |Sesquisquare|MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-23 00:01:42 UTC 
+Moon      |Trine       |MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-22 17:39:41 UTC 
+Venus     |Sesquisquare|MC       |2020-12-22 00:00:00 UTC |2020-12-24 00:00:00 UTC |2020-12-23 00:06:15 UTC 
 Mars      |Opposition  |Asc      |2020-08-18 00:00:00 UTC |2020-12-29 00:00:00 UTC |N/A                     
-Neptune   |BiQuintile  |Asc      |2019-05-19 00:00:00 UTC |2021-12-07 00:00:00 UTC |N/A                     
-Pluto     |Square      |Asc      |2020-03-08 00:00:00 UTC |2022-11-12 00:00:00 UTC |N/A                     
-Pluto     |Opposition  |MC       |2019-04-22 00:00:00 UTC |2021-12-05 00:00:00 UTC |N/A                     
+Neptune   |BiQuintile  |Asc      |2019-05-19 00:00:00 UTC |2021-12-08 00:00:00 UTC |N/A                     
+Pluto     |Square      |Asc      |2020-03-08 00:00:00 UTC |2022-11-13 00:00:00 UTC |N/A                     
+Pluto     |Opposition  |MC       |2020-01-24 00:00:00 UTC |2021-12-05 00:00:00 UTC |N/A                     
 


### PR DESCRIPTION
Introduces a more formal notion of an "aspect angle": it's the angle formed by two apparent positions, moving in an apparent phase, with an orb. Note that the apparent positions may not be the same as the _actual_ positions: one of the bodies may have to be considered 360 degrees away from its current position to be found in aspect; same with the apparent phase: it does not consider retrograde motion, simply the static position, which is always taken to be prograde for simplicity. We now carry more information, but are able to more easily derive information from this, vs. ad-hoc further processing to determine phases, orbs and actual angles.

closes #44 