### PR TITLE
Remove naïve strictness annotations

### DIFF
--- a/src/Ephemeris/Types.hs
+++ b/src/Ephemeris/Types.hs
@@ -274,25 +274,25 @@ data HoroscopeData = HoroscopeData
 
 data TransitData = TransitData
   {
-    natalPlanetPositions :: ![PlanetPosition]
-  , natalAngles :: !Angles
-  , natalHouses :: ![House]
-  , natalHouseSystem :: !HouseSystem
-  , transitingPlanetPositions :: ![PlanetPosition]
-  , transitingHouses :: ![House]
-  , transitingAngles :: !Angles
-  , transitingHouseSystem :: !HouseSystem
-  , planetaryTransits :: ![(PlanetaryAspect, PlanetaryTransit)]
-  , angleTransits :: ![(AngleAspect, AngleTransit)]
+    natalPlanetPositions :: [PlanetPosition]
+  , natalAngles :: Angles
+  , natalHouses :: [House]
+  , natalHouseSystem :: HouseSystem
+  , transitingPlanetPositions :: [PlanetPosition]
+  , transitingHouses :: [House]
+  , transitingAngles :: Angles
+  , transitingHouseSystem :: HouseSystem
+  , planetaryTransits :: [(PlanetaryAspect, PlanetaryTransit)]
+  , angleTransits :: [(AngleAspect, AngleTransit)]
   } deriving (Eq, Show)
 
 data Transit a = Transit
   {
-    transiting :: !PlanetPosition
-  , transited :: !a
-  , transitStarts :: !(Maybe UTCTime)
-  , transitEnds :: !(Maybe UTCTime)
-  , immediateTriggers :: ![UTCTime]
+    transiting :: PlanetPosition
+  , transited :: a
+  , transitStarts :: (Maybe UTCTime)
+  , transitEnds :: (Maybe UTCTime)
+  , immediateTriggers :: [UTCTime]
   } deriving stock (Eq, Show)
 
 type PlanetaryTransit = Transit PlanetPosition

--- a/test/Ephemeris/AspectSpec.hs
+++ b/test/Ephemeris/AspectSpec.hs
@@ -24,7 +24,7 @@ spec = do
           , (sq, (Longitude 95,  Longitude 10),  Just (Applying, 5))
           , (sq, (Longitude 100, Longitude 10),  Just (Exact, 0))
           , (sq, (Longitude 130, Longitude 10),  Nothing)
-          , (cnj, (Longitude 270, Longitude 270), Just (Exact, 0) )
+          , (cnj, (Longitude 270, Longitude 270), Just (Exact, 0))
           ]
         sq = Aspect{ aspectType = Major, aspectName = Square, angle = 90.0, maxOrb = 10.0, temperament = Analytical }
         cnj = Aspect{ aspectType = Major, aspectName = Conjunction, angle = 0.0, maxOrb = 10.0, temperament = Analytical }


### PR DESCRIPTION
Mostly because I couldn't quickly prove that adding them to all _other_ record types helped performance, and I have actually potentially proven the opposite? There was no method to it so won't make any claims -- just removing some surprise from the code until I do some proper profiling.